### PR TITLE
feat: add support for mac gpu

### DIFF
--- a/Labs/Week_3/CNN/helpers/methods.py
+++ b/Labs/Week_3/CNN/helpers/methods.py
@@ -1,3 +1,4 @@
+import platform
 import tensorflow as tf
 import os
 import requests
@@ -7,7 +8,7 @@ import matplotlib.pyplot as plt
 
 # Detects and sets the device to be used for training
 def detect_and_set_device():
-    if tf.test.is_built_with_cuda():
+    if tf.test.is_built_with_cuda() or platform.system() == "Darwin":
         physical_devices = tf.config.list_physical_devices('GPU')
         if len(physical_devices) > 0:
             print("GPU is available. Using GPU.")

--- a/Labs/Week_5/LSTM/helpers/methods.py
+++ b/Labs/Week_5/LSTM/helpers/methods.py
@@ -1,10 +1,11 @@
+import platform
 import tensorflow as tf
 from tensorflow.keras.datasets import imdb
 import matplotlib.pyplot as plt
 
 # Detects and sets the device to be used for training
 def detect_and_set_device():
-    if tf.test.is_built_with_cuda():
+    if tf.test.is_built_with_cuda() or platform.system() == "Darwin":
         physical_devices = tf.config.list_physical_devices('GPU')
         if len(physical_devices) > 0:
             print("GPU is available. Using GPU.")

--- a/Labs/Week_6/Self Attention/helpers/methods.py
+++ b/Labs/Week_6/Self Attention/helpers/methods.py
@@ -1,3 +1,4 @@
+import platform
 import tensorflow as tf
 import matplotlib.pyplot as plt
 from datasets import load_dataset
@@ -8,7 +9,7 @@ import seaborn as sns
 
 # Detects and sets the device to be used for training
 def detect_and_set_device():
-    if tf.test.is_built_with_cuda():
+    if tf.test.is_built_with_cuda() or platform.system() == "Darwin":
         physical_devices = tf.config.list_physical_devices('GPU')
         if len(physical_devices) > 0:
             print("GPU is available. Using GPU.")

--- a/Labs/Week_7/Transformers/helpers/methods.py
+++ b/Labs/Week_7/Transformers/helpers/methods.py
@@ -1,3 +1,4 @@
+import platform
 import tensorflow as tf
 import os
 import requests
@@ -8,7 +9,7 @@ import pandas as pd
 
 # Detects and sets the device to be used for training
 def detect_and_set_device():
-    if tf.test.is_built_with_cuda():
+    if tf.test.is_built_with_cuda() or platform.system() == "Darwin":
         physical_devices = tf.config.list_physical_devices('GPU')
         if len(physical_devices) > 0:
             print("GPU is available. Using GPU.")

--- a/Labs/Week_8/Deep Reinforcement Learning/helpers/methods.py
+++ b/Labs/Week_8/Deep Reinforcement Learning/helpers/methods.py
@@ -1,3 +1,4 @@
+import platform
 import tensorflow as tf
 import matplotlib.pyplot as plt
 import numpy as np
@@ -5,7 +6,7 @@ import imageio
 import os
 
 def detect_and_set_device():
-    if tf.test.is_built_with_cuda():
+    if tf.test.is_built_with_cuda() or platform.system() == "Darwin":
         physical_devices = tf.config.list_physical_devices('GPU')
         if len(physical_devices) > 0:
             print("GPU is available. Using GPU.")


### PR DESCRIPTION
### Overview
This merge request updates the `detect_and_set_device` function to enhance device detection logic, particularly for macOS (Darwin) systems. The changes ensure that the function correctly identifies and configures the appropriate device (GPU or CPU) for training, even on macOS platforms.

### Changes
1. **Device Detection Logic Update**:
   - Added a condition to check if the platform system is "Darwin" (macOS) in addition to checking if TensorFlow is built with CUDA support.
   - This ensures that the function can handle GPU detection on macOS systems where CUDA might not be directly available but GPU resources can still be utilized.


### Testing
- **Manual Testing**: The changes were tested on macOS and other platforms to verify that the device detection works as expected.

Please review the changes and provide feedback. Thank you!